### PR TITLE
fix: force numpy array to datatype int

### DIFF
--- a/nodes/coverage_progress
+++ b/nodes/coverage_progress
@@ -90,7 +90,7 @@ class CoverageProgressNode(object):
         grid.info.origin.orientation.w = 1
 
         # Initialize OccupancyGrid to have all cells DIRTY
-        grid.data = self.DIRTY * ones(grid.info.width * grid.info.height)
+        grid.data = self.DIRTY * ones(grid.info.width * grid.info.height, dtype=int)
 
         return grid
 


### PR DESCRIPTION
Node crashed when subscribing to coverage grid. Solved by forcing the numpy array to datatype int.